### PR TITLE
Fix house curve path detection for newer REW API responses

### DIFF
--- a/AudysseyOne.html
+++ b/AudysseyOne.html
@@ -557,9 +557,13 @@
     }
     const tcResponse = await fetch('http://localhost:4735/eq/house-curve');
     if (tcResponse.ok) {
-      const tcPath = await tcResponse.json();
-      if (tcPath && tcPath.message) {
-        console.log(`Applying Target Curve located @ ${tcPath.message}`);
+      const tcData = await tcResponse.json();
+      const tcPath =
+        typeof tcData === 'string'
+          ? tcData
+          : tcData?.message || tcData?.path || tcData?.file;
+      if (tcPath) {
+        console.log(`Applying Target Curve located @ ${tcPath}`);
       } else {
         throw new Error('Failed to locate target curve! Browse to and select "DrTooleTargetCurve.txt" in "REW / EQ window / House curve.');
       }


### PR DESCRIPTION
This fixes a false "Failed to locate target curve" error when REW returns the loaded house curve as a JSON string path from  instead of an object with a  field.\n\nThe change accepts both response shapes so existing behavior keeps working while newer REW builds are handled correctly.\n\nCloses #29.