### PR TITLE
Fix the warning log being used instead of the info log

### DIFF
--- a/AudysseyOne.html
+++ b/AudysseyOne.html
@@ -988,7 +988,7 @@
           const warningEntry = `${new Date().toLocaleTimeString()} [INFO] ${warningMessage}\n`;
           logContainer.textContent += warningEntry;
           scrollToBottom();
-          originalWarn.apply(console, args);
+          originalInfo.apply(console, args);
         };
     const originalLog = console.log;
     console.log = function (...args) {


### PR DESCRIPTION
Copy paste or typo bug where the previously created originalWarn log was used for the info messages instead of the newly created originalInfo log.