### PR TITLE
String truncation of 3 digit crossover value

### DIFF
--- a/AudysseyOne.html
+++ b/AudysseyOne.html
@@ -828,7 +828,7 @@
         }
         console.log(`Calculated optimal crossover frequency between ${newMeasurements[i].title.slice(0,-2)} and the subwoofer: ${xoFreq}Hz, nearest match in the unit: ${roundedXoFreq}Hz`)
         if (k === indexSW) {k++;}
-        customCrossover[k] = String(roundedXoFreq).slice(0, 2);
+        customCrossover[k] = String(roundedXoFreq);
         k++;
       }
       console.info(`Done!`);


### PR DESCRIPTION
I am not sure if this is a bug as I don't know what the multi eq app does with this field, however I can see the fixed crossover values can have up to 3 digits yet when it is set as a string it gets truncated to 2 digits.

100 becomes "10"

If 100 should be "100" then either remove the slice or make it slice(0,3). I removed slice as I don't see why it is needed in this context.